### PR TITLE
fix(block): video dialog no longer breaks page

### DIFF
--- a/src/blocks/video-carousel-block.tsx
+++ b/src/blocks/video-carousel-block.tsx
@@ -4,6 +4,7 @@
  */
 
 import React from "react";
+import ReactDOM from "react-dom";
 import { MediaUploadCheck, MediaUpload, RichText, useBlockProps } from "@wordpress/block-editor";
 import { Button } from "@wordpress/components";
 import { Heading } from "../components/heading";
@@ -175,12 +176,16 @@ export const VideoCarouselBlockSave = ({ attributes }: GutenCsekBlockSaveProps<V
 
         if (!video.url) return null;
 
-        if (customThumbnail) {
-            return <img className="vimeo-thumbnail" src={customThumbnail} key={index} />;
-        }
-
         if (usesVimeo) {
-            return <img className="vimeo-thumbnail" data-vimeo-url={video.url} key={index} />;
+            return (
+                <img
+                    className="vimeo-thumbnail"
+                    src={customThumbnail}
+                    key={index}
+                    data-vimeo-url={video.url}
+                    data-use-vimeo-thumbnail={false}
+                />
+            );
         }
         return (
             <video controls={false} key={index}>
@@ -213,16 +218,6 @@ export const VideoCarouselBlockSave = ({ attributes }: GutenCsekBlockSaveProps<V
 
     return (
         <section {...blockProps}>
-            <dialog className="video-player">
-                <a href="#closedialog" className="close-dialog">
-                    <i className="fas fa-x"></i>
-                </a>
-                <div className="player">
-                    <video controls={false} preload="none">
-                        Videos aren&apos;t supported in your browser. Frankly we&apos;re impressed you got this far.
-                    </video>
-                </div>
-            </dialog>
             <div className="video-strip">{videoElements}</div>
             <div className="video-carousel-slider-progress">
                 <div className="bar">

--- a/src/css/blocks/video-carousel-block.css
+++ b/src/css/blocks/video-carousel-block.css
@@ -73,24 +73,4 @@
             }
         }
     }
-
-    & dialog.video-player {
-        @apply fixed bg-csek-dark rounded-md shadow-lg opacity-0 w-11/12 aspect-video;
-
-        &[open] {
-            @apply opacity-100;
-        }
-
-        & .player {
-            @apply w-full h-full overflow-hidden;
-
-            & iframe {
-                @apply w-full h-full;
-            }
-        }
-
-        & .close-dialog {
-            @apply absolute top-2 right-4 text-base text-white drop-shadow-lg z-20 cursor-pointer;
-        }
-    }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ window.addEventListener("load", (e) => {
         window.domController.setup();
         window.domController.overrideAllDebug(false);
         window.domController.debug = true;
-        window.domController.overrideDebug(true, "ProcessBlock");
+        window.domController.overrideDebug(true, "VideoCarouselBlock");
     });
 
     setTimeout(() => {


### PR DESCRIPTION
Fixes: #5 

## Description

Video dialog no longer breaks page flow (and actually displays videos again after last major change).