### PR TITLE
feat(blocks): Post Collage Block

### DIFF
--- a/src/blocks/blog/post-collage-block.tsx
+++ b/src/blocks/blog/post-collage-block.tsx
@@ -84,6 +84,7 @@ export const PostCollageBlockEdit = ({
                 />
                 <TextInput
                     label="Number of Posts to Display"
+                    hint="This is the number of of posts to display in the first part of the collage. If there are more posts than this number, a featured post is added and the remaining posts are shown below."
                     onChange={(value: string) => {
                         setAttributes({ postCount: parseInt(value) });
                     }}

--- a/src/blocks/blog/post-collage-block.tsx
+++ b/src/blocks/blog/post-collage-block.tsx
@@ -16,7 +16,7 @@ import {
     getAllPosts,
     getTagsByCategory,
 } from "../../scripts/wp";
-import { CsekSelectDropdown } from "../../components/input";
+import { CsekSelectDropdown, TextInput } from "../../components/input";
 import CsekCard from "../../components/card";
 import { useBlockProps } from "@wordpress/block-editor";
 
@@ -69,7 +69,7 @@ export const PostCollageBlockEdit = ({
     return (
         <section>
             <CsekBlockHeading text="Post Collage Block" />
-            <CsekCard>
+            <CsekCard className="flex flex-col gap-4">
                 <CsekSelectDropdown
                     label="Category"
                     options={parentCategories.map((c) => {
@@ -82,64 +82,16 @@ export const PostCollageBlockEdit = ({
                     }}
                     initialValue={categorySlug}
                 />
-                <pre>{JSON.stringify(parentCategories, null, 2)}</pre>
+                <TextInput
+                    label="Number of Posts to Display"
+                    onChange={(value: string) => {
+                        setAttributes({ postCount: parseInt(value) });
+                    }}
+                    initialValue={postCount.toString()}
+                    type="number"
+                />
             </CsekCard>
         </section>
-    );
-};
-
-interface RelatedPostProps {
-    post: WPPost;
-    tags: PostTag[];
-}
-
-const RelatedPost = ({ post, tags }: RelatedPostProps) => {
-    const { url, title, featuredImage, readTime } = post;
-
-    const tagLimit = 2;
-
-    const tagLinks: JSX.Element[] = tags
-        .filter((_, index: number) => {
-            return index < tagLimit;
-        })
-        .map((tag: PostTag) => {
-            return (
-                <a href={tag.url} key={tag.slug} className="chip">
-                    {tag.name}
-                </a>
-            );
-        });
-
-    if (tags.length > tagLimit) {
-        const remainingTags = tags
-            .slice(tagLimit)
-            .map((tag: PostTag) => {
-                return tag.name;
-            })
-            .join(", ");
-
-        tagLinks.push(
-            <a href="#" key="more" className="chip" title={remainingTags}>
-                +{tags.length - tagLimit}
-            </a>
-        );
-    }
-
-    return (
-        <div className="related-post">
-            <div className="featured-image">
-                <img src={featuredImage.medium} />
-            </div>
-            <div className="text-content">
-                <h2 className="title">
-                    <a href={url}>{title}</a>
-                </h2>
-                <div className="read-time">
-                    <span>{readTime}</span> MIN READ
-                </div>
-                <div className="tags">{tagLinks}</div>
-            </div>
-        </div>
     );
 };
 

--- a/src/blocks/blog/post-collage-block.tsx
+++ b/src/blocks/blog/post-collage-block.tsx
@@ -70,20 +70,24 @@ export const PostCollageBlockEdit = ({
         <section>
             <CsekBlockHeading text="Post Collage Block" />
             <CsekCard className="flex flex-col gap-4">
-                <CsekSelectDropdown
-                    label="Category"
-                    options={parentCategories.map((c) => {
-                        return { label: c.name, value: c.slug };
-                    })}
-                    onChange={(value: string) => {
-                        const category = findCategoryId(parentCategories, value);
-                        setCurrentCategory(category ?? -1);
-                        setCategorySlug(value);
-                    }}
-                    initialValue={categorySlug}
-                />
+                {parentCategories.length === 0 ? (
+                    <p>Loading categories...</p>
+                ) : (
+                    <CsekSelectDropdown
+                        label="Category"
+                        options={parentCategories.map((c) => {
+                            return { label: c.name, value: c.slug };
+                        })}
+                        onChange={(value: string) => {
+                            const category = findCategoryId(parentCategories, value);
+                            setCurrentCategory(category ?? -1);
+                            setCategorySlug(value);
+                        }}
+                        initialValue={categorySlug}
+                    />
+                )}
                 <TextInput
-                    label="Number of Posts to Display"
+                    label="Number of Posts in First Section"
                     hint="This is the number of of posts to display in the first part of the collage. If there are more posts than this number, a featured post is added and the remaining posts are shown below."
                     onChange={(value: string) => {
                         setAttributes({ postCount: parseInt(value) });

--- a/src/blocks/blog/post-collage-block.tsx
+++ b/src/blocks/blog/post-collage-block.tsx
@@ -121,9 +121,6 @@ export const PostCollageBlockSave = ({ attributes }: GutenCsekBlockSaveProps<Pos
                     </ul>
                 </nav>
                 <div className="collage-related-posts"></div>
-                <div className="featured-post">
-                    <div className="inner"></div>
-                </div>
             </div>
         </section>
     );

--- a/src/blocks/blog/post-collage-block.tsx
+++ b/src/blocks/blog/post-collage-block.tsx
@@ -153,7 +153,7 @@ export const PostCollageBlockSave = ({ attributes }: GutenCsekBlockSaveProps<Pos
             data-post-count={postCount}
             data-chosen-category={chosenCategory}
             data-found-tags={JSON.stringify(foundTags)}>
-            <div className="block-content">
+            <div className="inner-container">
                 <nav className="tag-nav">
                     <ul>
                         <li>
@@ -169,6 +169,9 @@ export const PostCollageBlockSave = ({ attributes }: GutenCsekBlockSaveProps<Pos
                     </ul>
                 </nav>
                 <div className="collage-related-posts"></div>
+                <div className="featured-post">
+                    <div className="inner"></div>
+                </div>
             </div>
         </section>
     );

--- a/src/blocks/blog/post-collage-block.tsx
+++ b/src/blocks/blog/post-collage-block.tsx
@@ -1,0 +1,88 @@
+/*
+ * Created on Wed Dec 27 2023
+ * Author: Connor Doman
+ */
+
+import React, { useEffect, useState } from "react";
+import { useSelect } from "@wordpress/data";
+import { GutenCsekBlockEditProps, GutenCsekBlockSaveProps } from "../../scripts/dom";
+import { CsekBlockHeading } from "../../components/heading";
+import {
+    PostCategory,
+    findCategoryId,
+    getAllCategories,
+    getAllPosts,
+    getAllTags,
+    getTagsByCategory,
+} from "../../scripts/wp";
+import { CsekSelectDropdown } from "../../components/input";
+
+export interface PostCollageBlockAttributes {
+    chosenTag: string;
+    postCount: number;
+    foundTags: string[];
+    featuredPost: number;
+}
+
+export const PostCollageBlockEdit = ({
+    attributes,
+    setAttributes,
+}: GutenCsekBlockEditProps<PostCollageBlockAttributes>) => {
+    const [tags, setTags] = useState<any>({});
+    const [allTags, setAllTags] = useState<any>({});
+    const [parentCategories, setParentCategories] = useState<PostCategory[]>([]);
+    const [posts, setPosts] = useState<any>({});
+    const [currentCategory, setCurrentCategory] = useState<string>("");
+
+    useEffect(() => {
+        getAllTags().then((tags) => {
+            setAllTags(tags);
+        });
+
+        getAllCategories().then((categories) => {
+            setParentCategories(categories);
+        });
+
+        getAllPosts().then((posts) => {
+            setPosts(posts);
+        });
+    }, []);
+
+    useEffect(() => {
+        if (currentCategory) {
+            const cId = findCategoryId(parentCategories, currentCategory);
+            if (!cId) return;
+
+            getAllPosts(undefined, [cId]).then((posts) => {
+                setPosts(posts);
+            });
+
+            getTagsByCategory(cId).then((tags) => {
+                setTags(tags);
+            });
+        }
+    }, [currentCategory, parentCategories]);
+
+    return (
+        <div>
+            <CsekBlockHeading text="Post Collage Block" />
+            <CsekSelectDropdown
+                options={parentCategories.map((c) => {
+                    return { label: c.name, value: c.slug };
+                })}
+                onChange={(value: string) => {
+                    setCurrentCategory(value);
+                }}
+            />
+            <pre>{JSON.stringify(parentCategories, null, 2)}</pre>
+        </div>
+    );
+};
+
+export const PostCollageBlockSave = ({ attributes }: GutenCsekBlockSaveProps<PostCollageBlockAttributes>) => {
+    return (
+        <div>
+            <p>Post Collage Block</p>
+        </div>
+    );
+};

--- a/src/blocks/misc/featured-image-block.tsx
+++ b/src/blocks/misc/featured-image-block.tsx
@@ -63,7 +63,13 @@ export const FeaturedImageBlockEdit = ({
                     placeholder="Image alt text"
                     label="Image Alt Text"
                 />
-                <CsekMediaUpload onChange={onChangeImageURL} urlAttribute={imageURL} type="image" size="large" />
+                <CsekMediaUpload
+                    onChange={onChangeImageURL}
+                    urlAttribute={imageURL}
+                    type="image"
+                    size="large"
+                    altText={imageAlt}
+                />
             </div>
         </section>
     );

--- a/src/blocks/misc/featured-video-block.tsx
+++ b/src/blocks/misc/featured-video-block.tsx
@@ -9,7 +9,7 @@ import { GutenCsekBlockEditProps, GutenCsekBlockSaveProps, GutenbergBlockProps }
 import { InspectorControls, useBlockProps } from "@wordpress/block-editor";
 import { CsekMediaUpload } from "../../components/media-upload";
 import { CsekBlockHeading } from "../../components/heading";
-import CsekPaddingSelector, { Padding } from "../../components/padding-selector";
+import CsekPaddingSelector, { Padding, defaultPadding, styleFromPadding } from "../../components/padding-selector";
 import Label from "../../components/label";
 
 export interface FeaturedVideoBlockAttributes {
@@ -33,8 +33,9 @@ export const FeaturedVideoBlockEdit = ({
 
     const { videoURL, padding } = attributes;
 
-    const handleChangeVideoURL = (v: any) => {
-        setAttributes({ videoURL: v.url });
+    const handleChangeVideoURL = (url: string) => {
+        console.log("video url: ", url);
+        setAttributes({ videoURL: url });
     };
 
     const handleChangePadding = (padding: Padding) => {
@@ -50,7 +51,7 @@ export const FeaturedVideoBlockEdit = ({
             <Label>
                 Check the Inspector panel to edit padding <i className="fa fa-arrow-right"></i>
             </Label>
-            <CsekMediaUpload type="video" urlAttribute={videoURL} onChange={handleChangeVideoURL} />
+            <CsekMediaUpload type="video" urlAttribute={videoURL} onChange={(url, alt) => handleChangeVideoURL(url)} />
         </div>
     );
 };
@@ -58,10 +59,12 @@ export const FeaturedVideoBlockEdit = ({
 export const FeaturedVideoBlockSave = ({ attributes }: GutenCsekBlockSaveProps<FeaturedVideoBlockAttributes>) => {
     const blockProps = useBlockProps.save();
 
-    const { videoURL } = attributes;
+    const { videoURL, padding } = attributes;
+
+    const p = styleFromPadding(padding ?? defaultPadding);
 
     return (
-        <section {...blockProps}>
+        <section {...blockProps} style={p}>
             <div className="block-container">
                 <div className="video-container">
                     <div className="video-shade"></div>

--- a/src/components/heading.tsx
+++ b/src/components/heading.tsx
@@ -45,7 +45,7 @@ export const CsekBlockHeading = ({ text, className, children }: CsekBlockHeading
             level="2"
             children={children}
             text={text}
-            className={twMerge("border-b border-solid border-black pb-px my-2 text-4xl", className)}
+            className={twMerge("border-b border-solid border-black pb-px my-2 text-3xl font-syne", className)}
         />
     );
 };

--- a/src/components/input.tsx
+++ b/src/components/input.tsx
@@ -16,6 +16,7 @@ interface InputProps {
     hint?: string;
     className?: string;
     disabled?: boolean;
+    type?: "text" | "number";
     onChange?: (v: string) => void;
 }
 
@@ -26,12 +27,16 @@ export const TextInput = ({
     hint,
     className,
     disabled,
+    type = "text",
     onChange,
 }: InputProps) => {
     const [text, setText] = useState<string>(initialValue);
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const newValue = e.target.value as string;
+        if (type === "number" && isNaN(Number(newValue))) {
+            return;
+        }
         setText(newValue);
         if (onChange) {
             onChange(newValue);

--- a/src/components/media-upload.tsx
+++ b/src/components/media-upload.tsx
@@ -13,7 +13,7 @@ import { CsekImage } from "../scripts/image";
 import { twMerge } from "tailwind-merge";
 
 interface CsekMediaUploadProps {
-    onChange: (v: string, altText: string) => void;
+    onChange: (v: string, altText?: string) => void;
     urlAttribute?: string;
     type?: "image" | "video" | "audio";
     label?: string;
@@ -33,10 +33,16 @@ export const CsekMediaUpload = ({
     const [resourceId, setResourceId] = useState(0);
 
     const handleChangeURL = async (v: any) => {
-        const resource = new CsekImage(v.id);
-        await resource.doubleCheckSizes();
+        if (type === "audio") return;
+        else if (type === "video") {
+            console.log("video url: ", v.url);
+            onChange(v.url);
+            setResourceURL(v.url);
+            setResourceId(v.id);
+            return;
+        }
 
-        const resUrl = () => {
+        const resUrl = (resource: CsekImage) => {
             switch (size) {
                 case "thumbnail":
                     return resource.thumbnail;
@@ -50,8 +56,11 @@ export const CsekMediaUpload = ({
                     return resource.full;
             }
         };
+
+        const resource = new CsekImage(v.id);
+        await resource.doubleCheckSizes();
         // alert("Resource info: " + JSON.stringify({ ...resource }, null, 4));
-        onChange(resUrl(), resource.altText);
+        onChange(resUrl(resource), resource.altText);
         setResourceURL(v.url);
         setResourceId(v.id);
     };

--- a/src/components/media-upload.tsx
+++ b/src/components/media-upload.tsx
@@ -18,6 +18,7 @@ interface CsekMediaUploadProps {
     type?: "image" | "video" | "audio";
     label?: string;
     size?: "thumbnail" | "medium" | "large" | "full";
+    altText?: string;
     className?: string;
 }
 
@@ -27,6 +28,7 @@ export const CsekMediaUpload = ({
     type = "image",
     label,
     size = "full",
+    altText = "",
     className = "",
 }: CsekMediaUploadProps) => {
     const [resourceURL, setResourceURL] = useState(urlAttribute);
@@ -57,7 +59,7 @@ export const CsekMediaUpload = ({
             }
         };
 
-        const resource = new CsekImage(v.id);
+        const resource = new CsekImage(v.id, "image", altText || undefined);
         await resource.doubleCheckSizes();
         // alert("Resource info: " + JSON.stringify({ ...resource }, null, 4));
         onChange(resUrl(resource), resource.altText);

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -3,9 +3,12 @@
 @import "tailwindcss/utilities";
 
 @import "animations.css";
+
 @import "components/stack.css";
 @import "components/button.css";
+
 @import "style.css";
+
 @import "blocks/block-quote-block.css";
 @import "blocks/curtainify.css";
 @import "blocks/expanding-video-block.css";
@@ -31,4 +34,7 @@
 @import "blocks/team-block.css";
 @import "blocks/video-carousel-block.css";
 @import "blocks/process-block.css";
+
 @import "blocks/projects/masonry-block.css";
+
+@import "blocks/blog/post-collage-block.css";

--- a/src/css/blocks/blog/post-collage-block.css
+++ b/src/css/blocks/blog/post-collage-block.css
@@ -22,43 +22,47 @@
         }
 
         & .collage-related-posts {
-            @apply relative flex sm:grid sm:grid-cols-2 md:grid-cols-3 flex-col sm:flex-row items-start justify-around gap-4 w-11/12 max-w-csek-max mx-auto py-8 flex-wrap transition-all duration-750;
+            @apply relative flex flex-col justify-start items-center w-full;
 
-            & .related-post {
-                @apply relative flex-grow flex flex-col box-border;
+            & .related-posts-grid {
+                @apply relative flex sm:grid sm:grid-cols-2 md:grid-cols-3 flex-col sm:flex-row items-start justify-around gap-4 w-11/12 max-w-csek-max mx-auto py-8 flex-wrap transition-all duration-750;
 
-                &:hover .title::after {
-                    content: "More";
-                    @apply opacity-100;
-                }
+                & .related-post {
+                    @apply relative flex-grow flex flex-col box-border;
 
-                & .text-content {
-                    @apply flex flex-col gap-4 py-2;
-                }
-
-                & .title {
-                    @apply relative text-csek-dark font-bold font-syne text-xl md:text-2xl my-4;
-
-                    &::after {
+                    &:hover .title::after {
                         content: "More";
-                        @apply opacity-0 transition-opacity duration-200 pointer-events-none absolute -top-20 left-1/2 transform -translate-x-1/2 w-20 h-20 rounded-full inline-flex flex-col items-center justify-center bg-csek-dark z-[1000] text-sm uppercase text-white font-montserrat font-medium;
+                        @apply opacity-100;
                     }
-                }
 
-                & .featured-image {
-                    @apply relative rounded-md overflow-hidden;
-
-                    & img {
-                        @apply w-full h-full object-cover object-top;
+                    & .text-content {
+                        @apply flex flex-col gap-4 py-2;
                     }
-                }
 
-                & .read-time {
-                    @apply text-sm font-medium uppercase;
-                }
+                    & .title {
+                        @apply relative text-csek-dark font-bold font-syne text-xl md:text-2xl my-2;
 
-                & .tags {
-                    @apply flex flex-row gap-2 items-center justify-start flex-wrap;
+                        &::after {
+                            content: "More";
+                            @apply opacity-0 transition-opacity duration-200 pointer-events-none absolute -top-[5.25rem] left-1/2 transform -translate-x-1/2 w-20 h-20 rounded-full inline-flex flex-col items-center justify-center bg-csek-dark z-[1000] text-sm uppercase text-white font-montserrat font-medium;
+                        }
+                    }
+
+                    & .featured-image {
+                        @apply relative rounded-md overflow-hidden;
+
+                        & img {
+                            @apply w-full h-full object-cover object-top;
+                        }
+                    }
+
+                    & .read-time {
+                        @apply text-sm font-medium uppercase;
+                    }
+
+                    & .tags {
+                        @apply flex flex-row gap-2 items-center justify-start flex-wrap;
+                    }
                 }
             }
         }

--- a/src/css/blocks/blog/post-collage-block.css
+++ b/src/css/blocks/blog/post-collage-block.css
@@ -22,21 +22,31 @@
         }
 
         & .collage-related-posts {
-            @apply relative flex sm:grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 flex-col sm:flex-row items-start justify-around gap-4 w-11/12 max-w-csek-max mx-auto py-8 flex-wrap transition-all duration-750;
+            @apply relative flex sm:grid sm:grid-cols-2 md:grid-cols-3 flex-col sm:flex-row items-start justify-around gap-4 w-11/12 max-w-csek-max mx-auto py-8 flex-wrap transition-all duration-750;
 
             & .related-post {
                 @apply relative flex-grow flex flex-col box-border;
+
+                &:hover .title::after {
+                    content: "More";
+                    @apply opacity-100;
+                }
 
                 & .text-content {
                     @apply flex flex-col gap-4 py-2;
                 }
 
                 & .title {
-                    @apply text-csek-dark font-bold font-syne text-xl md:text-2xl;
+                    @apply relative text-csek-dark font-bold font-syne text-xl md:text-2xl my-4;
+
+                    &::after {
+                        content: "More";
+                        @apply opacity-0 transition-opacity duration-200 pointer-events-none absolute -top-20 left-1/2 transform -translate-x-1/2 w-20 h-20 rounded-full inline-flex flex-col items-center justify-center bg-csek-dark z-[1000] text-sm uppercase text-white font-montserrat font-medium;
+                    }
                 }
 
                 & .featured-image {
-                    @apply rounded-md overflow-hidden;
+                    @apply relative rounded-md overflow-hidden;
 
                     & img {
                         @apply w-full h-full object-cover object-top;
@@ -54,7 +64,7 @@
         }
 
         & .featured-post {
-            @apply bg-csek-dark relative w-full flex-grow hidden flex-col box-border sm:col-span-2 md:col-span-3 lg:col-span-4 -my-4 overflow-hidden;
+            @apply bg-csek-dark relative w-full flex-grow hidden flex-col box-border overflow-hidden;
 
             &.visible {
                 @apply flex;

--- a/src/css/blocks/blog/post-collage-block.css
+++ b/src/css/blocks/blog/post-collage-block.css
@@ -1,0 +1,18 @@
+/*
+ * Created on Sat Dec 30 2023
+ * Author: Connor Doman
+ */
+
+.wp-block-guten-csek-post-collage-block {
+    & .block-content {
+        @apply max-w-csek-max mx-auto;
+
+        & nav ul {
+            @apply flex flex-wrap justify-start;
+
+            & li {
+                @apply px-2 py-1 border-b-2 border-transparent hover:border-csek-red transition-all duration-200 cursor-pointer;
+            }
+        }
+    }
+}

--- a/src/css/blocks/blog/post-collage-block.css
+++ b/src/css/blocks/blog/post-collage-block.css
@@ -22,10 +22,14 @@
         }
 
         & .collage-related-posts {
-            @apply relative flex flex-col justify-start items-center w-full;
+            @apply relative flex flex-col justify-start items-center transition-opacity duration-750 min-h-[75vh];
+
+            &.hide {
+                @apply opacity-0 pointer-events-none;
+            }
 
             & .related-posts-grid {
-                @apply relative flex sm:grid sm:grid-cols-2 md:grid-cols-3 flex-col sm:flex-row items-start justify-around gap-4 w-11/12 max-w-csek-max mx-auto py-8 flex-wrap transition-all duration-750;
+                @apply relative flex sm:grid sm:grid-cols-2 md:grid-cols-3 flex-col sm:flex-row items-start justify-around gap-x-4 gap-y-8 w-11/12 max-w-csek-max mx-auto py-8 flex-wrap transition-all duration-750;
 
                 & .related-post {
                     @apply relative flex-grow flex flex-col box-border;
@@ -65,34 +69,44 @@
                     }
                 }
             }
-        }
 
-        & .featured-post {
-            @apply bg-csek-dark relative w-full flex-grow hidden flex-col box-border overflow-hidden;
+            & .featured-post {
+                @apply relative bg-csek-dark flex-grow flex-col box-border h-80 min-h-[50vh] w-screen;
 
-            &.visible {
-                @apply flex;
-            }
+                &.visible {
+                    @apply flex;
+                }
 
-            & .inner {
-                @apply w-full max-w-csek-max mx-auto flex flex-col justify-center items-start h-full py-4 bg-cover;
+                & .inner {
+                    @apply relative w-full h-full max-w-csek-max mx-auto flex flex-col justify-center items-start py-8 bg-cover;
 
-                &::after {
-                    @apply max-w-csek-max;
-                    content: "";
-                    position: absolute;
-                    top: 0;
-                    left: 50%;
-                    width: 100%;
-                    height: 100%;
-                    background: linear-gradient(
-                        to right,
-                        #131313 0%,
-                        rgba(255, 255, 255, 0) 25%,
-                        rgba(255, 255, 255, 0) 75%,
-                        #131313 100%
-                    );
-                    transform: translateX(-50%);
+                    &::after {
+                        @apply max-w-csek-max;
+                        content: "";
+                        position: absolute;
+                        top: 0;
+                        left: 50%;
+                        width: 100%;
+                        height: 100%;
+                        background: radial-gradient(circle, rgba(255, 255, 255, 0) 0%, #131313 95%);
+                        transform: translateX(-50%);
+                    }
+
+                    & .featured-content {
+                        @apply w-11/12 h-full max-w-csek-max mx-auto flex flex-col justify-end items-start z-10 gap-4;
+
+                        & .title {
+                            @apply relative text-white font-bold font-syne text-xl md:text-2xl my-2 drop-shadow-lg;
+                        }
+
+                        & .read-time {
+                            @apply text-sm font-medium uppercase text-white;
+                        }
+
+                        & .tags {
+                            @apply flex flex-row gap-2 items-center justify-start flex-wrap;
+                        }
+                    }
                 }
             }
         }

--- a/src/css/blocks/blog/post-collage-block.css
+++ b/src/css/blocks/blog/post-collage-block.css
@@ -4,13 +4,17 @@
  */
 
 .wp-block-guten-csek-post-collage-block {
-    @apply relative py-16;
+    @apply relative md:py-8;
 
     & .inner-container {
         @apply flex flex-col justify-start items-center w-full;
 
+        & .tag-nav {
+            @apply w-full;
+        }
+
         & nav ul {
-            @apply w-11/12 max-w-csek-max mx-auto flex flex-wrap justify-center md:justify-start gap-y-2;
+            @apply w-11/12 max-w-csek-max mx-auto flex flex-wrap justify-center sm:justify-start gap-y-2;
 
             & li a {
                 @apply px-2 py-1 border-b-2 border-transparent hover:border-csek-red transition-all duration-200 cursor-pointer font-syne text-sm;
@@ -22,7 +26,7 @@
         }
 
         & .collage-related-posts {
-            @apply relative flex flex-col justify-start items-center transition-opacity duration-750 min-h-[75vh];
+            @apply relative flex flex-col justify-start items-center transition-opacity duration-750 min-h-[75vh] my-8;
 
             &.hide {
                 @apply opacity-0 pointer-events-none;
@@ -44,7 +48,7 @@
                     }
 
                     & .title {
-                        @apply relative text-csek-dark font-bold font-syne text-xl md:text-2xl my-2;
+                        @apply relative text-csek-dark font-bold font-syne text-xl md:text-2xl my-2 text-pretty;
 
                         &::after {
                             content: "More";

--- a/src/css/blocks/blog/post-collage-block.css
+++ b/src/css/blocks/blog/post-collage-block.css
@@ -4,14 +4,52 @@
  */
 
 .wp-block-guten-csek-post-collage-block {
+    @apply relative;
+
     & .block-content {
         @apply max-w-csek-max mx-auto;
 
         & nav ul {
-            @apply flex flex-wrap justify-start;
+            @apply flex flex-wrap justify-start gap-y-2;
 
-            & li {
-                @apply px-2 py-1 border-b-2 border-transparent hover:border-csek-red transition-all duration-200 cursor-pointer;
+            & li a {
+                @apply px-2 py-1 border-b-2 border-transparent hover:border-csek-red transition-all duration-200 cursor-pointer font-syne text-sm;
+
+                &.chosen {
+                    @apply border-csek-red text-csek-red;
+                }
+            }
+        }
+
+        & .collage-related-posts {
+            @apply relative flex flex-col sm:flex-row items-start justify-around gap-4 w-11/12 max-w-csek-max mx-auto py-8 flex-wrap transition-all duration-500;
+
+            & .related-post {
+                @apply relative flex-grow basis-full sm:basis-1/2 md:basis-1/3 lg:basis-1/4 max-w-full sm:max-w-[50%] md:max-w-[33.3%] lg:max-w-[25%] flex flex-col box-border;
+
+                & .text-content {
+                    @apply flex flex-col gap-4 py-2;
+                }
+
+                & .title {
+                    @apply text-csek-dark font-bold font-syne text-xl md:text-2xl;
+                }
+
+                & .featured-image {
+                    @apply rounded-md overflow-hidden;
+
+                    & img {
+                        @apply w-full h-full object-cover object-top;
+                    }
+                }
+
+                & .read-time {
+                    @apply text-sm font-medium uppercase;
+                }
+
+                & .tags {
+                    @apply flex flex-row gap-2 items-center justify-start flex-wrap;
+                }
             }
         }
     }

--- a/src/css/blocks/blog/post-collage-block.css
+++ b/src/css/blocks/blog/post-collage-block.css
@@ -4,13 +4,13 @@
  */
 
 .wp-block-guten-csek-post-collage-block {
-    @apply relative;
+    @apply relative py-16;
 
-    & .block-content {
-        @apply max-w-csek-max mx-auto;
+    & .inner-container {
+        @apply flex flex-col justify-start items-center w-full;
 
         & nav ul {
-            @apply flex flex-wrap justify-start gap-y-2;
+            @apply w-11/12 max-w-csek-max mx-auto flex flex-wrap justify-center md:justify-start gap-y-2;
 
             & li a {
                 @apply px-2 py-1 border-b-2 border-transparent hover:border-csek-red transition-all duration-200 cursor-pointer font-syne text-sm;
@@ -22,10 +22,10 @@
         }
 
         & .collage-related-posts {
-            @apply relative flex flex-col sm:flex-row items-start justify-around gap-4 w-11/12 max-w-csek-max mx-auto py-8 flex-wrap transition-all duration-500;
+            @apply relative flex sm:grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 flex-col sm:flex-row items-start justify-around gap-4 w-11/12 max-w-csek-max mx-auto py-8 flex-wrap transition-all duration-750;
 
             & .related-post {
-                @apply relative flex-grow basis-full sm:basis-1/2 md:basis-1/3 lg:basis-1/4 max-w-full sm:max-w-[50%] md:max-w-[33.3%] lg:max-w-[25%] flex flex-col box-border;
+                @apply relative flex-grow flex flex-col box-border;
 
                 & .text-content {
                     @apply flex flex-col gap-4 py-2;
@@ -49,6 +49,36 @@
 
                 & .tags {
                     @apply flex flex-row gap-2 items-center justify-start flex-wrap;
+                }
+            }
+        }
+
+        & .featured-post {
+            @apply bg-csek-dark relative w-full flex-grow hidden flex-col box-border sm:col-span-2 md:col-span-3 lg:col-span-4 -my-4 overflow-hidden;
+
+            &.visible {
+                @apply flex;
+            }
+
+            & .inner {
+                @apply w-full max-w-csek-max mx-auto flex flex-col justify-center items-start h-full py-4 bg-cover;
+
+                &::after {
+                    @apply max-w-csek-max;
+                    content: "";
+                    position: absolute;
+                    top: 0;
+                    left: 50%;
+                    width: 100%;
+                    height: 100%;
+                    background: linear-gradient(
+                        to right,
+                        #131313 0%,
+                        rgba(255, 255, 255, 0) 25%,
+                        rgba(255, 255, 255, 0) 75%,
+                        #131313 100%
+                    );
+                    transform: translateX(-50%);
                 }
             }
         }

--- a/src/css/blocks/misc/featured-video-block.css
+++ b/src/css/blocks/misc/featured-video-block.css
@@ -4,61 +4,28 @@
  */
 
 .wp-block-guten-csek-featured-video-block {
-    width: 100%;
-    position: relative;
-    padding: 3rem 0;
+    @apply w-full relative;
 
     & .block-container {
-        max-width: var(--max-width);
-        margin: 0 auto;
-        position: relative;
+        @apply relative mx-auto w-11/12 max-w-csek-max;
 
         & .video-container {
-            position: relative;
-            padding-bottom: 56.25%;
-            height: 0;
-            overflow: hidden;
-            border-radius: 0.5rem;
-            width: 100%;
+            @apply relative pb-[56.25%] h-0 overflow-hidden rounded-lg;
 
             & > * {
-                transition: all ease 0.2s;
+                @apply transition-all ease-in-out duration-200;
             }
 
             & .video-shade {
-                position: absolute;
-                top: 0;
-                left: 0;
-                width: 100%;
-                height: 100%;
-                background: linear-gradient(black, transparent);
-                z-index: 2;
-                pointer-events: none;
+                @apply absolute top-0 left-0 w-full h-full bg-gradient-to-b from-black to-transparent z-[2] pointer-events-none;
             }
 
             & video {
-                z-index: 1;
+                @apply z-[1];
             }
 
             & .playbutton {
-                font-family: "Syne", sans-serif;
-                font-weight: bold;
-                text-transform: uppercase;
-                position: absolute;
-                top: 50%;
-                left: 50%;
-                transform: translate(-50%, -50%);
-                width: 7rem;
-                height: 7rem;
-                border-radius: 50%;
-                background: var(--csek-blue);
-                display: flex;
-                flex-direction: column;
-                justify-content: center;
-                align-items: center;
-                gap: 0.5rem;
-                cursor: pointer;
-                z-index: 3;
+                @apply font-syne font-bold uppercase absolute top-1/2 left-1/2 translate-center w-28 h-28 rounded-full bg-csek-blue flex flex-col justify-center items-center gap-2 cursor-pointer z-[3];
             }
         }
     }

--- a/src/css/editor.css
+++ b/src/css/editor.css
@@ -107,3 +107,35 @@ h4 {
     gap: 0.5rem;
     padding: 1rem;
 }
+
+.wp-block-paragraph {
+    @apply my-4;
+}
+
+.wp-block-heading {
+    @apply font-bold my-2 font-syne;
+}
+
+h1.wp-block-heading {
+    @apply text-4xl;
+}
+
+h2.wp-block-heading {
+    @apply text-3xl;
+}
+
+h3.wp-block-heading {
+    @apply text-2xl;
+}
+
+h4.wp-block-heading {
+    @apply text-xl;
+}
+
+h5.wp-block-heading {
+    @apply text-lg;
+}
+
+h6.wp-block-heading {
+    @apply text-base;
+}

--- a/src/domcontroller.ts
+++ b/src/domcontroller.ts
@@ -18,6 +18,7 @@ import CyclingStackController from "./scripts/controllers/cycling-stack-controll
 import ProjectsMarqueeController from "./scripts/controllers/projects-marquee-controller";
 import ProcessBlockController from "./blocks/process-block";
 import { ProjectsMasonryController } from "./blocks/projects/masonry-block";
+import PostCollageController from "./scripts/controllers/blog/post-collage-controller";
 
 export const createDOMController = () => {
     /* Prepare DOM Controller */
@@ -60,6 +61,9 @@ export const createDOMController = () => {
     // Projects Masonry Block
     const projectsMasonryBlock = new ProjectsMasonryController();
 
+    // Post Collage Block
+    const postCollageController = new PostCollageController();
+
     // DOM controller
     return new DOMController(
         curtainifyController,
@@ -74,6 +78,7 @@ export const createDOMController = () => {
         cyclingStackController,
         teamController,
         processBlockController,
-        projectsMasonryBlock
+        projectsMasonryBlock,
+        postCollageController
     );
 };

--- a/src/scripts/controllers/blog/post-collage-controller.ts
+++ b/src/scripts/controllers/blog/post-collage-controller.ts
@@ -4,7 +4,15 @@
  */
 
 import { BlockController } from "../../dom";
-import { PostTag, WPPost, generateRelatedPostDOM, getAllPosts, getCategoryBySlug, getTagsByCategory } from "../../wp";
+import {
+    PostTag,
+    WPPost,
+    generateRelatedPostDOM,
+    getAllPosts,
+    getCategoryBySlug,
+    getTagsByCategory,
+    makeTagList,
+} from "../../wp";
 
 interface RelatedPostDOM {
     tags: number[];
@@ -73,16 +81,6 @@ class PostCollageBlock {
             this.relatedPostsArea.style.opacity = "1";
         });
 
-        this.featuredPostArea = this.block.querySelector(".featured-post .inner") as HTMLElement;
-        this.featuredPostArea.style.backgroundImage = `url(${
-            this.posts[(Math.random() * this.posts.length) | 0].featuredImage.full
-        })`;
-        if (this.posts.length > this.postCount) {
-            this.featuredPostArea.classList.add("visible");
-        } else {
-            this.featuredPostArea.classList.remove("visible");
-        }
-
         this.tagLinks.forEach((link) => {
             link.addEventListener("click", async (e) => {
                 e.preventDefault();
@@ -108,6 +106,52 @@ class PostCollageBlock {
                 link.classList.remove("chosen");
             }
         });
+    }
+
+    async createRelatedPostGrid(posts: WPPost[]) {
+        const grid = document.createElement("div");
+        grid.classList.add("related-posts-grid");
+
+        for (const post of posts) {
+            const postDOM = await generateRelatedPostDOM(post);
+            grid.appendChild(postDOM);
+        }
+
+        return grid;
+    }
+
+    async createFeaturedPost(post: WPPost) {
+        const featuredPost = document.createElement("div");
+        featuredPost.classList.add("featured-post");
+
+        const featuredInner = document.createElement("div");
+        featuredInner.classList.add("inner");
+        featuredInner.style.backgroundImage = `url(${
+            this.posts[(Math.random() * this.posts.length) | 0].featuredImage.full
+        })`;
+        if (this.posts.length > this.postCount) {
+            featuredInner.classList.add("visible");
+        } else {
+            featuredInner.classList.remove("visible");
+        }
+
+        const featuredContent = document.createElement("div");
+        featuredContent.classList.add("featured-content");
+
+        const featuredTitle = document.createElement("h2");
+        featuredTitle.classList.add("featured-title");
+
+        const readTime = document.createElement("div");
+        readTime.classList.add("read-time");
+        readTime.innerHTML = `${post.readTime} min read`;
+
+        const tags = document.createElement("div");
+        tags.classList.add("tags");
+        tags.append(...(await makeTagList(post)));
+
+        featuredContent.append(featuredTitle, readTime, tags);
+        featuredInner.appendChild(featuredContent);
+        featuredPost.appendChild(featuredInner);
     }
 }
 

--- a/src/scripts/controllers/blog/post-collage-controller.ts
+++ b/src/scripts/controllers/blog/post-collage-controller.ts
@@ -1,0 +1,123 @@
+/*
+ * Created on Tue Jan 02 2024
+ * Author: Connor Doman
+ */
+
+import { BlockController } from "../../dom";
+import { PostTag, WPPost, generateRelatedPostDOM, getAllPosts, getCategoryBySlug, getTagsByCategory } from "../../wp";
+
+class PostCollageBlock {
+    block: HTMLElement;
+    category: number;
+    currentTag: number;
+    posts: WPPost[];
+    tags: PostTag[];
+
+    tagLinks: NodeListOf<HTMLAnchorElement>;
+    relatedPostsArea: HTMLElement;
+
+    log: (...args: any[]) => void;
+
+    constructor(block: HTMLElement, log = console.log) {
+        this.block = block;
+        this.category = -1;
+        this.currentTag = -1;
+        this.posts = [];
+        this.tags = [];
+        this.log = log;
+    }
+
+    async setup() {
+        this.category = parseInt(this.block.dataset.chosenCategory ?? "-1");
+        this.tags = JSON.parse(this.block.dataset.foundTags || "[]") as PostTag[];
+
+        this.tagLinks = this.block.querySelectorAll(".tag-nav ul li a");
+        this.relatedPostsArea = this.block.querySelector(".collage-related-posts") as HTMLElement;
+
+        this.tagLinks.forEach((link) => {
+            link.addEventListener("click", async (e) => {
+                e.preventDefault();
+
+                const id = parseInt(link.dataset.tagId ?? "-1");
+
+                if (id === -1) {
+                    return;
+                }
+
+                this.currentTag = id;
+                await this.update();
+            });
+        });
+
+        await this.update();
+    }
+
+    async update() {
+        const tagList = this.currentTag > -1 ? [this.currentTag] : undefined;
+        this.posts = await getAllPosts(tagList, [this.category]);
+
+        console.log(this.posts);
+
+        this.relatedPostsArea.style.opacity = "0";
+        this.relatedPostsArea.innerHTML = "";
+
+        for (const post of this.posts) {
+            const postElement = await generateRelatedPostDOM(post);
+            this.relatedPostsArea.appendChild(postElement);
+            // this.relatedPostsArea.style.height = `${relatedPostsBox.height}px`;
+            this.relatedPostsArea.style.opacity = "1";
+        }
+
+        this.tagLinks.forEach((link) => {
+            const id = parseInt(link.dataset.tagId ?? "-1");
+            if (id === this.currentTag) {
+                link.classList.add("chosen");
+            } else {
+                link.classList.remove("chosen");
+            }
+        });
+    }
+}
+
+export default class PostCollageController extends BlockController {
+    blocks: NodeListOf<HTMLElement>;
+
+    collageBlocks: PostCollageBlock[];
+
+    constructor() {
+        super();
+        this.name = "PostCollageBlock";
+        this.collageBlocks = [];
+    }
+
+    setup(): void {
+        this.debug = true;
+
+        this.blocks = document.querySelectorAll(".wp-block-guten-csek-post-collage-block");
+
+        if (this.invalid(this.blocks.length)) {
+            this.err("No blocks found");
+            return;
+        }
+
+        this.blocks.forEach((block) => {
+            const collageBlock = new PostCollageBlock(block, (...args: any[]) => this.log(...args));
+            this.collageBlocks.push(collageBlock);
+        });
+
+        this.collageBlocks.forEach((collageBlock, index: number) => {
+            this.log(`Setting up collage block ${index}`);
+            collageBlock.setup();
+        });
+
+        this.isInitialized = true;
+    }
+
+    async setupBlocks() {
+        for (const collageBlock of this.collageBlocks) {
+            await collageBlock.setup();
+        }
+    }
+
+    onMouseMove?(e: MouseEvent, blockIndex: number): void {}
+}

--- a/src/scripts/controllers/blog/post-collage-controller.ts
+++ b/src/scripts/controllers/blog/post-collage-controller.ts
@@ -69,8 +69,8 @@ class PostCollageBlock {
         this.tagLinks = this.block.querySelectorAll(".tag-nav ul li a");
         this.relatedPostsArea = this.block.querySelector(".collage-related-posts") as HTMLElement;
 
-        const gridElements = await this.buildPostsGrid(this.relatedPosts);
-        this.relatedPostsArea.append(...gridElements);
+        // const gridElements = await this.buildPostsGrid(this.relatedPosts);
+        // this.relatedPostsArea.append(...gridElements);
 
         this.relatedPostsArea.addEventListener("transitionend", (e) => {
             const target = e.target as HTMLElement;
@@ -101,7 +101,11 @@ class PostCollageBlock {
             });
         });
 
-        this.tagLinks.forEach((link) => {
+        this.tagLinks.forEach((link, index) => {
+            if (index === 0) {
+                link.classList.add("chosen");
+            }
+
             link.addEventListener("click", async (e) => {
                 e.preventDefault();
 

--- a/src/scripts/controllers/blog/post-collage-controller.ts
+++ b/src/scripts/controllers/blog/post-collage-controller.ts
@@ -6,15 +6,24 @@
 import { BlockController } from "../../dom";
 import { PostTag, WPPost, generateRelatedPostDOM, getAllPosts, getCategoryBySlug, getTagsByCategory } from "../../wp";
 
+interface RelatedPostDOM {
+    tags: number[];
+    dom: HTMLElement;
+}
+
 class PostCollageBlock {
     block: HTMLElement;
     category: number;
     currentTag: number;
+    postCount: number;
     posts: WPPost[];
     tags: PostTag[];
 
     tagLinks: NodeListOf<HTMLAnchorElement>;
     relatedPostsArea: HTMLElement;
+    featuredPostArea: HTMLElement;
+
+    relatedPosts: RelatedPostDOM[];
 
     log: (...args: any[]) => void;
 
@@ -24,25 +33,61 @@ class PostCollageBlock {
         this.currentTag = -1;
         this.posts = [];
         this.tags = [];
+        this.relatedPosts = [];
         this.log = log;
     }
 
     async setup() {
         this.category = parseInt(this.block.dataset.chosenCategory ?? "-1");
         this.tags = JSON.parse(this.block.dataset.foundTags || "[]") as PostTag[];
+        this.postCount = parseInt(this.block.dataset.postCount ?? "6");
+
+        this.posts = await getAllPosts(undefined, [this.category]);
+
+        for (const p of this.posts) {
+            const dom = await generateRelatedPostDOM(p);
+
+            const related = {
+                tags: p.tags,
+                dom,
+            };
+
+            this.relatedPosts.push(related);
+        }
 
         this.tagLinks = this.block.querySelectorAll(".tag-nav ul li a");
         this.relatedPostsArea = this.block.querySelector(".collage-related-posts") as HTMLElement;
+
+        this.relatedPosts.forEach((related) => {
+            this.relatedPostsArea.appendChild(related.dom);
+        });
+
+        this.relatedPostsArea.addEventListener("transitionend", () => {
+            for (const post of this.relatedPosts) {
+                if (this.currentTag === -1 || post.tags.includes(this.currentTag)) {
+                    post.dom.style.display = "block";
+                } else {
+                    post.dom.style.display = "none";
+                }
+            }
+            this.relatedPostsArea.style.opacity = "1";
+        });
+
+        this.featuredPostArea = this.block.querySelector(".featured-post .inner") as HTMLElement;
+        this.featuredPostArea.style.backgroundImage = `url(${
+            this.posts[(Math.random() * this.posts.length) | 0].featuredImage.full
+        })`;
+        if (this.posts.length > this.postCount) {
+            this.featuredPostArea.classList.add("visible");
+        } else {
+            this.featuredPostArea.classList.remove("visible");
+        }
 
         this.tagLinks.forEach((link) => {
             link.addEventListener("click", async (e) => {
                 e.preventDefault();
 
                 const id = parseInt(link.dataset.tagId ?? "-1");
-
-                if (id === -1) {
-                    return;
-                }
 
                 this.currentTag = id;
                 await this.update();
@@ -53,20 +98,7 @@ class PostCollageBlock {
     }
 
     async update() {
-        const tagList = this.currentTag > -1 ? [this.currentTag] : undefined;
-        this.posts = await getAllPosts(tagList, [this.category]);
-
-        console.log(this.posts);
-
         this.relatedPostsArea.style.opacity = "0";
-        this.relatedPostsArea.innerHTML = "";
-
-        for (const post of this.posts) {
-            const postElement = await generateRelatedPostDOM(post);
-            this.relatedPostsArea.appendChild(postElement);
-            // this.relatedPostsArea.style.height = `${relatedPostsBox.height}px`;
-            this.relatedPostsArea.style.opacity = "1";
-        }
 
         this.tagLinks.forEach((link) => {
             const id = parseInt(link.dataset.tagId ?? "-1");

--- a/src/scripts/image.ts
+++ b/src/scripts/image.ts
@@ -3,8 +3,6 @@
  * Author: Connor Doman
  */
 
-import apiFetch from "@wordpress/api-fetch";
-
 interface ImageSizeData {
     file: string;
     width: number;
@@ -19,8 +17,13 @@ export class CsekImage {
     private alt: string;
     private sizes: { [key: string]: ImageSizeData };
 
-    constructor(id: number) {
+    private type: "image" | "video";
+
+    private _url: string;
+
+    constructor(id: number, type: "image" | "video" = "image") {
         this.id = id;
+        this.type = type;
 
         this.preload();
     }
@@ -32,6 +35,10 @@ export class CsekImage {
             const data = await response.json();
             this.alt = data.alt_text;
             this.sizes = data.media_details.sizes;
+
+            if (this.type === "video") {
+                this._url = data.source_url;
+            }
         } catch (err: any) {
             console.log(`[CsekImage] Error: ${err}`);
         }
@@ -40,6 +47,15 @@ export class CsekImage {
     async doubleCheckSizes() {
         if (!this.sizes) {
             await this.preload();
+        }
+    }
+
+    get url(): string {
+        switch (this.type) {
+            case "image":
+                return this.full;
+            case "video":
+                return this._url;
         }
     }
 

--- a/src/scripts/image.ts
+++ b/src/scripts/image.ts
@@ -31,7 +31,7 @@ export class CsekImage {
     async preload() {
         try {
             const response = await fetch(`/wp-json/wp/v2/media/${this.id}?context=embed`);
-            console.log(await response.clone().json());
+
             const data = await response.json();
             this.alt = data.alt_text;
             this.sizes = data.media_details.sizes;
@@ -60,18 +60,22 @@ export class CsekImage {
     }
 
     get thumbnail(): string {
+        if (!this.sizes) return "";
         return this.sizes.thumbnail.source_url;
     }
 
     get medium(): string {
+        if (!this.sizes) return "";
         return this.sizes.medium.source_url;
     }
 
     get large(): string {
+        if (!this.sizes) return "";
         return this.sizes.large.source_url;
     }
 
     get full(): string {
+        if (!this.sizes) return "";
         return this.sizes.full.source_url;
     }
 

--- a/src/scripts/register-blocks.ts
+++ b/src/scripts/register-blocks.ts
@@ -766,8 +766,8 @@ export const registerAllBlocks = () => {
         category: "csek",
         attributes: {
             chosenCategory: {
-                type: "string",
-                default: "blog",
+                type: "number",
+                default: -1,
             },
             postCount: {
                 type: "number",
@@ -776,10 +776,6 @@ export const registerAllBlocks = () => {
             foundTags: {
                 type: "array",
                 default: [],
-            },
-            featuredPost: {
-                type: "number",
-                default: -1,
             },
         },
         edit: PostCollageBlockEdit,

--- a/src/scripts/register-blocks.ts
+++ b/src/scripts/register-blocks.ts
@@ -765,7 +765,7 @@ export const registerAllBlocks = () => {
         icon: "text",
         category: "csek",
         attributes: {
-            chosenTag: {
+            chosenCategory: {
                 type: "string",
                 default: "blog",
             },

--- a/src/scripts/register-blocks.ts
+++ b/src/scripts/register-blocks.ts
@@ -87,6 +87,11 @@ import { TeamBlockEdit, TeamBlockSave } from "../blocks/team-block";
 import ProcessBlockController, { ProcessBlockAttributes } from "../blocks/process-block";
 import ProjectsMasonryBlock, { ProjectsMasonryBlockAttributes } from "../blocks/projects/masonry-block";
 import { defaultPadding } from "../components/padding-selector";
+import {
+    PostCollageBlockAttributes,
+    PostCollageBlockEdit,
+    PostCollageBlockSave,
+} from "../blocks/blog/post-collage-block";
 
 export const registerAllBlocks = () => {
     console.log("Registering blocks...");
@@ -752,5 +757,32 @@ export const registerAllBlocks = () => {
         },
         edit: ProjectsMasonryBlock.editComponent,
         save: ProjectsMasonryBlock.saveComponent,
+    });
+
+    // Post Collage Block
+    registerBlockType<PostCollageBlockAttributes>("guten-csek/post-collage-block", {
+        title: "Csek Post Collage Block",
+        icon: "text",
+        category: "csek",
+        attributes: {
+            chosenTag: {
+                type: "string",
+                default: "blog",
+            },
+            postCount: {
+                type: "number",
+                default: 6,
+            },
+            foundTags: {
+                type: "array",
+                default: [],
+            },
+            featuredPost: {
+                type: "number",
+                default: -1,
+            },
+        },
+        edit: PostCollageBlockEdit,
+        save: PostCollageBlockSave,
     });
 };

--- a/src/scripts/strings.ts
+++ b/src/scripts/strings.ts
@@ -40,3 +40,13 @@ export const urlExtractSecondLevelDomain = (url: string): string => {
 export const capitalize = (str: string): string => {
     return str.charAt(0).toUpperCase() + str.slice(1);
 };
+
+export const removeHTMLTags = (str: string): string => {
+    const cleanText = str.replace(/<\/?[^>]+(>|$)/g, "");
+    return cleanText;
+};
+
+export const decodeHtmlEntities = (str: string): string => {
+    const doc = new DOMParser().parseFromString(str, "text/html");
+    return doc.documentElement.textContent || "";
+};

--- a/src/scripts/wp.ts
+++ b/src/scripts/wp.ts
@@ -69,7 +69,6 @@ export async function getAllPosts(tags?: number[], categories?: number[]) {
 export async function getAllTags(): Promise<PostTag[]> {
     try {
         const res = await fetch(`/wp-json/wp/v2/tags?context=view`);
-        console.log("found tags");
         const tagData = await res.json();
 
         const tags: PostTag[] = [];
@@ -94,10 +93,7 @@ export async function getAllTags(): Promise<PostTag[]> {
 export async function getAllCategories(): Promise<PostCategory[]> {
     try {
         const res = await fetch(`/wp-json/wp/v2/categories?context=view`);
-        console.log("found categories");
         const categoryData = await res.json();
-
-        console.table(categoryData);
 
         const categories: PostCategory[] = [];
 
@@ -114,8 +110,6 @@ export async function getAllCategories(): Promise<PostCategory[]> {
                 });
             }
         });
-
-        console.info(parentCategories);
 
         categoryData.forEach((category: any) => {
             if (category.parent !== 0) {
@@ -242,16 +236,21 @@ export async function generateRelatedPostDOM(post: WPPost): Promise<HTMLElement>
     postLink.classList.add("post-link");
 
     const featuredImage = document.createElement("img");
-    featuredImage.classList.add("featured-image");
-    featuredImage.src = post.featuredImage.large;
-    featuredImage.alt = post.featuredImage.altText;
+    if (post.featuredImage) {
+        featuredImage.classList.add("featured-image");
+        featuredImage.src = post.featuredImage.getSize("large", "full");
+        featuredImage.alt = post.featuredImage.altText;
+        postLink.append(featuredImage);
+    }
 
     const textContent = document.createElement("div");
     textContent.classList.add("text-content");
 
     const title = document.createElement("h2");
     title.classList.add("title");
-    title.innerHTML = post.title;
+    const splitTitle = decodeHtmlEntities(post.title).split("|");
+    const mainTitle = splitTitle[0].trim();
+    title.innerText = mainTitle;
 
     const readTime = document.createElement("div");
     readTime.classList.add("read-time");
@@ -263,7 +262,7 @@ export async function generateRelatedPostDOM(post: WPPost): Promise<HTMLElement>
 
     textContent.append(title, readTime);
 
-    postLink.append(featuredImage, textContent);
+    postLink.append(textContent);
 
     postDOM.append(postLink, tags);
 

--- a/src/scripts/wp.ts
+++ b/src/scripts/wp.ts
@@ -4,7 +4,7 @@
  */
 
 import { CsekImage } from "./image";
-import { removeHTMLTags } from "./strings";
+import { decodeHtmlEntities, removeHTMLTags } from "./strings";
 
 export interface WPPost {
     id: number;
@@ -215,10 +215,10 @@ export async function makeTagList(post: WPPost): Promise<HTMLElement[]> {
         });
 
     if (postTags.length > tagLimit) {
-        const remainingTags = allTags
+        const remainingTags = postTags
             .slice(tagLimit)
             .map((tag: PostTag) => {
-                return tag.name;
+                return decodeHtmlEntities(tag.name);
             })
             .join(", ");
         const moreTagLink = document.createElement("a");
@@ -237,6 +237,10 @@ export async function generateRelatedPostDOM(post: WPPost): Promise<HTMLElement>
     const postDOM = document.createElement("div");
     postDOM.classList.add("related-post");
 
+    const postLink = document.createElement("a");
+    postLink.href = post.url;
+    postLink.classList.add("post-link");
+
     const featuredImage = document.createElement("img");
     featuredImage.classList.add("featured-image");
     featuredImage.src = post.featuredImage.large;
@@ -247,10 +251,7 @@ export async function generateRelatedPostDOM(post: WPPost): Promise<HTMLElement>
 
     const title = document.createElement("h2");
     title.classList.add("title");
-    const titleLink = document.createElement("a");
-    titleLink.href = post.url;
-    titleLink.innerHTML = post.title;
-    title.appendChild(titleLink);
+    title.innerHTML = post.title;
 
     const readTime = document.createElement("div");
     readTime.classList.add("read-time");
@@ -260,9 +261,11 @@ export async function generateRelatedPostDOM(post: WPPost): Promise<HTMLElement>
     tags.classList.add("tags");
     tags.append(...(await makeTagList(post)));
 
-    textContent.append(title, readTime, tags);
+    textContent.append(title, readTime);
 
-    postDOM.append(featuredImage, textContent);
+    postLink.append(featuredImage, textContent);
+
+    postDOM.append(postLink, tags);
 
     return postDOM;
 }

--- a/src/scripts/wp.ts
+++ b/src/scripts/wp.ts
@@ -1,0 +1,163 @@
+/*
+ * Created on Sat Dec 30 2023
+ * Author: Connor Doman
+ */
+
+export interface WPPost {
+    id: number;
+    url: string;
+    slug: string;
+    title: string;
+    categories: number[];
+    tags: number[];
+    featuredImage: number;
+}
+
+export interface PostTag {
+    id: number;
+    name: string;
+    slug: string;
+    description: string;
+    url: string;
+}
+
+export interface PostCategory {
+    id: number;
+    name: string;
+    slug: string;
+    description: string;
+    url: string;
+    children?: PostCategory[];
+}
+
+export async function getAllPosts(tags?: number[], categories?: number[]) {
+    try {
+        const tagQuery = tags ? "&tags=" + tags.join(",") : "";
+        const categoryQuery = categories ? "&categories=" + categories.join(",") : "";
+        const res = await fetch(`/wp-json/wp/v2/posts?context=view${tagQuery}${categoryQuery}`);
+        const postsData = await res.json();
+
+        const posts: WPPost[] = [];
+
+        postsData.forEach((post: any) => {
+            posts.push({
+                id: post.id,
+                url: post.link,
+                slug: post.slug,
+                title: post.title.rendered,
+                categories: post.categories,
+                tags: post.tags,
+                featuredImage: post.featured_media,
+            });
+        });
+
+        return posts;
+    } catch (error: any) {
+        console.error(error);
+    }
+    return [];
+}
+
+export async function getAllTags(): Promise<PostTag[]> {
+    try {
+        const res = await fetch(`/wp-json/wp/v2/tags?context=view`);
+        console.log("found tags");
+        const tagData = await res.json();
+
+        const tags: PostTag[] = [];
+
+        tagData.forEach((tag: any) => {
+            tags.push({
+                id: tag.id,
+                name: tag.name,
+                slug: tag.slug,
+                description: tag.description,
+                url: tag.link,
+            });
+        });
+
+        return tags;
+    } catch (error: any) {
+        console.error(error);
+    }
+    return [];
+}
+
+export async function getAllCategories(): Promise<PostCategory[]> {
+    try {
+        const res = await fetch(`/wp-json/wp/v2/categories?context=view`);
+        console.log("found categories");
+        const categoryData = await res.json();
+
+        console.table(categoryData);
+
+        const categories: PostCategory[] = [];
+
+        const parentCategories: Set<PostCategory> = new Set();
+
+        categoryData.forEach((category: any) => {
+            if (category.parent === 0) {
+                parentCategories.add({
+                    id: category.id,
+                    name: category.name,
+                    slug: category.slug,
+                    description: category.description,
+                    url: category.link,
+                });
+            }
+        });
+
+        console.info(parentCategories);
+
+        categoryData.forEach((category: any) => {
+            if (category.parent !== 0) {
+                const parent = [...parentCategories].find((parent) => parent.id === category.parent);
+                if (parent) {
+                    if (!parent.children) {
+                        parent.children = [];
+                    }
+                    parent.children.push({
+                        id: category.id,
+                        name: category.name,
+                        slug: category.slug,
+                        description: category.description,
+                        url: category.link,
+                    });
+                }
+            }
+        });
+
+        parentCategories.forEach((parent) => {
+            categories.push(parent);
+        });
+
+        return categories;
+    } catch (error) {
+        console.error(error);
+    }
+    return [];
+}
+
+export async function getTagsByCategory(...categories: number[]): Promise<PostTag[]> {
+    const allTags: PostTag[] = await getAllTags();
+
+    const foundTags = new Set<PostTag>();
+
+    const posts = await getAllPosts(undefined, categories);
+
+    posts.forEach((post: WPPost) => {
+        post.tags.forEach((tagId: number) => {
+            const tag = allTags.find((tag) => tag.id === tagId);
+            if (tag) {
+                foundTags.add(tag);
+            }
+        });
+    });
+
+    return [...foundTags];
+}
+
+export function findCategoryId(categories: PostCategory[], slug: string): number | undefined {
+    const category = categories.find((category) => category.slug === slug);
+    return category?.id;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 const theme = require("./theme.json");
 const tailpress = require("@jeffreyvr/tailwindcss-tailpress");
+const plugin = require("tailwindcss/plugin");
 
 const customWidths = {
     "csek-max": "75rem",
@@ -88,4 +89,14 @@ module.exports = {
         },
     },
     // plugins: [tailpress.tailwind],
+    plugins: [
+        plugin(function ({ addUtilities }) {
+            const newUtilities = {
+                ".translate-center": {
+                    transform: "translate(-50%, -50%)",
+                },
+            };
+            addUtilities(newUtilities);
+        }),
+    ],
 };


### PR DESCRIPTION
Closes: #100 

## Description

The page at `/blog` needs a way to display all posts for the blog. In the pursuit of flexibility, I have written a generic block that allows the user to select the category of post to display. When the editor is saved, the tags from all posts within the selected category are saved to the block. When the page is loaded, all posts of that category are retrieved and populated, and the user is able to filter the posts by included tags.

The user can also select a display number for the first segment of the block. e.g. if the user chooses 6 posts and there are 20 posts in that category, 6 of them will display in the upper block, then a random post will be selected as the featured post, and then the remainder of the posts will be shown below. If there are fewer total posts to display than the number, no featured post will be shown.