### PR TITLE
fix(scrolling-projects): projects no longer undefined

### DIFF
--- a/src/scripts/array.ts
+++ b/src/scripts/array.ts
@@ -9,7 +9,7 @@ export const shuffle = (array: any[]) => {
     let currentIndex = array.length;
     let randomIndex = 0;
 
-    const newArray = [...array];
+    const newArray = array.map((el) => el);
 
     while (currentIndex !== 0) {
         randomIndex = randomIntInRange(0, currentIndex);

--- a/src/scripts/controllers/projects-marquee-controller.ts
+++ b/src/scripts/controllers/projects-marquee-controller.ts
@@ -105,6 +105,7 @@ export default class ProjectsMarqueeController extends BlockController {
 
         for (let i = 0; i < projects.length; i++) {
             const innerText = projects[i].innerText;
+            // this.log(`project ${i}: ${innerText}`);
             if (!innerText) continue;
 
             if (!projectNames.includes(innerText)) projectNames.push(innerText);

--- a/src/scripts/marquee/row.ts
+++ b/src/scripts/marquee/row.ts
@@ -28,7 +28,6 @@ export class Strip {
 
     constructor(mq: MarqueeCanvas, words: string[]) {
         this.mq = mq;
-        this.words = shuffle(words);
 
         if (this.mq.separator) {
             this.words = [];
@@ -36,6 +35,8 @@ export class Strip {
                 this.words.push(word);
                 this.words.push(this.mq.separator);
             }
+        } else {
+            this.words = shuffle(words);
         }
 
         const dimensions = this.calculateDimensions();
@@ -213,23 +214,23 @@ export class Row {
         switch (this.direction) {
             case 1:
                 if (this.primaryRibbon.offset >= this.mq.width) {
-                    this.log("Moving primary ribbon behind");
+                    // this.log("Moving primary ribbon behind");
                     this.moveRibbonBehind(this.primaryRibbon, this.secondaryRibbon);
                 }
 
                 if (this.secondaryRibbon.offset >= this.mq.width) {
-                    this.log("Moving secondary ribbon behind");
+                    // this.log("Moving secondary ribbon behind");
                     this.moveRibbonBehind(this.secondaryRibbon, this.primaryRibbon);
                 }
                 break;
             case -1:
                 if (this.primaryRibbon.offset <= -this.primaryRibbon.width) {
-                    this.log("Moving primary ribbon ahead");
+                    // this.log("Moving primary ribbon ahead");
                     this.moveRibbonAhead(this.primaryRibbon, this.secondaryRibbon);
                 }
 
                 if (this.secondaryRibbon.offset <= -this.secondaryRibbon.width) {
-                    this.log("Moving secondary ribbon ahead");
+                    // this.log("Moving secondary ribbon ahead");
                     this.moveRibbonAhead(this.secondaryRibbon, this.primaryRibbon);
                 }
                 break;

--- a/src/scripts/math.ts
+++ b/src/scripts/math.ts
@@ -33,11 +33,11 @@ export const randomInRange = (min: number, max: number): number => {
 /**
  * Generate a random integer between min and max
  * @param min the lower bound of the range
- * @param max the upper bound of the range (inclusive)
+ * @param max the upper bound of the range (exclusive)
  * @returns a random integer between min and max
  */
 export const randomIntInRange = (min: number, max: number): number => {
-    return Math.floor(Math.random() * (max - min + 1)) + min;
+    return Math.floor(Math.random() * (max - min)) + min;
 };
 
 export const randomPartOfOne = (): number => {


### PR DESCRIPTION
# Bug Fix for Guten Csek :microbe:

Fixes: #119 

## Description

Scrolling projects sometimes show up as `undefined` in the marquee

## How was it fixed?

`randomIntInRange(...)` was inclusive and caused shuffled arrays to sometimes grow by one element and that element would be `undefined`. Changed this to inclusive.

:fish_cake:
