### PR TITLE
fix(seo): remove H1 tags from non-heading blocks

### DIFF
--- a/src/blocks/horizontal-carousel-block.tsx
+++ b/src/blocks/horizontal-carousel-block.tsx
@@ -104,9 +104,9 @@ export const HorizontalCarouselBlockSave = ({
     for (let i = 0; i < numItems; i++) {
         items.push(
             <li key={i} className="carousel-item">
-                <h1>{i + 1}</h1>
+                <h2>{i + 1}</h2>
                 <div className="carousel-item-body">
-                    <h2>{titles[i]}</h2>
+                    <h3>{titles[i]}</h3>
                     <p>{statements[i]}</p>
                 </div>
             </li>

--- a/src/blocks/misc/next-project-block.tsx
+++ b/src/blocks/misc/next-project-block.tsx
@@ -64,10 +64,10 @@ export const NextProjectBlockSave = ({ attributes }: GutenCsekBlockSaveProps<Nex
                 </div>
                 <div className="next-project-info">
                     <a href={projectLink}>
-                        <h1>Next project</h1>
+                        <h2>Next project</h2>
                         <i className="fa fa-arrow-right"></i>
                     </a>
-                    <h2>{projectTitle}</h2>
+                    <h3>{projectTitle}</h3>
                 </div>
             </div>
         </section>

--- a/src/blocks/misc/staff-profiles-block.tsx
+++ b/src/blocks/misc/staff-profiles-block.tsx
@@ -242,7 +242,7 @@ const StaffProfileComponent = ({ name, position, description, socialMedia, image
                 <div className="bio">
                     <header>
                         <div className="name">
-                            <h1>{name}</h1>
+                            <h2>{name}</h2>
                             <CloseButton />
                         </div>
                         <h2>{position}</h2>
@@ -278,9 +278,9 @@ const StaffProfileSummary = ({ name, position, imageURL, fullProfile }: StaffPro
                 <img src={imageURL} alt={name + "'s profile photo"} />
             </div>
             <div className="info">
-                <h1>{name}</h1>
+                <h2>{name}</h2>
                 <span className="separator">•</span>
-                <h2>{position}</h2>
+                <h3>{position}</h3>
             </div>
             {fullProfile}
         </div>
@@ -300,7 +300,7 @@ export const StaffProfilesBlockSave = ({ attributes }: GutenCsekBlockSaveProps<S
         <section {...blockProps} className="" style={{ marginBottom: alternateLayout ? "0" : "-10rem" }}>
             <div className="block-content">
                 <div className="block-header">
-                    <h2>{heading}</h2>
+                    <h3>{heading}</h3>
                     {caption ? <p>{caption}</p> : null}
                 </div>
                 <div className={`profiles-area ${alternateLayout ? "alternate" : ""}`}>{profileElements}</div>

--- a/src/blocks/process-block.tsx
+++ b/src/blocks/process-block.tsx
@@ -340,7 +340,7 @@ export default class ProcessBlockController extends BlockController {
 
             return (
                 <section className="step">
-                    <h2>{title}</h2>
+                    <h3>{title}</h3>
                     <p>{description}</p>
                 </section>
             );
@@ -348,10 +348,10 @@ export default class ProcessBlockController extends BlockController {
 
         return (
             <section {...blockProps}>
-                <h1 className="process-title">
+                <h2 className="process-title">
                     <span className="left-digit">0</span>
                     <div className="right-digits">{stepNumbers}</div>
-                </h1>
+                </h2>
                 <div className="block-content">
                     <div className="process-image">{stepImages}</div>
                     <div className="process-steps">{stepElements}</div>

--- a/src/blocks/process-block.tsx
+++ b/src/blocks/process-block.tsx
@@ -85,7 +85,7 @@ export default class ProcessBlockController extends BlockController {
 
             const stepElements = block.querySelectorAll(".step");
             stepElements.forEach((step: Element) => {
-                const stepTitle = step.querySelector("h2") as HTMLElement;
+                const stepTitle = step.querySelector("h3") as HTMLElement;
                 const stepDescription = step.querySelector("p") as HTMLElement;
                 const stepImage = step.querySelector("img") as HTMLImageElement;
 

--- a/src/css/blocks/misc/next-project-block.css
+++ b/src/css/blocks/misc/next-project-block.css
@@ -29,7 +29,7 @@
         & a {
             @apply flex flex-row items-center justify-start no-underline text-csek-dark cursor-pointer;
 
-            & h1 {
+            & h2 {
                 @apply text-2xl md:text-5xl font-semibold m-0 p-0 border-b border-solid border-transparent transition-all duration-200 ease-in-out leading-[0.75];
             }
 
@@ -38,7 +38,7 @@
             }
 
             &:hover {
-                & h1 {
+                & h2 {
                     @apply border-csek-dark;
                 }
 
@@ -48,7 +48,7 @@
             }
         }
 
-        & h2 {
+        & h3 {
             @apply text-csek-red font-bold uppercase;
         }
     }

--- a/src/css/blocks/misc/staff-profiles-block.css
+++ b/src/css/blocks/misc/staff-profiles-block.css
@@ -26,11 +26,11 @@
             & header {
                 @apply z-30 font-syne font-bold uppercase pb-4 shadow-lg shadow-white;
 
-                & h1 {
+                & h2 {
                     @apply text-3xl md:text-6xl leading-none;
                 }
 
-                & h2 {
+                & h3 {
                     @apply text-base text-csek-red my-1;
                 }
 
@@ -76,7 +76,7 @@
 .wp-block-guten-csek-staff-profiles-block .block-header {
     @apply flex flex-col md:flex-row justify-start items-start font-montserrat gap-8 md:gap-24 mb-8 pt-12 md:pt-16 w-11/12 max-w-csek-max mx-auto;
 
-    & h2 {
+    & h3 {
         @apply font-syne text-4xl leading-[1.1] w-min font-bold;
     }
 
@@ -182,11 +182,11 @@
     & .info {
         @apply flex flex-row justify-between w-full items-start font-syne font-bold text-csek-red text-sm leading-none my-1;
 
-        & h1 {
-            @apply text-base md:text-sm leading-none uppercase m-0 text-csek-dark whitespace-nowrap;
+        & h2 {
+            @apply text-base md:text-sm md:leading-none leading-none uppercase m-0 text-csek-dark whitespace-nowrap;
         }
 
-        & h2 {
+        & h3 {
             @apply text-right;
         }
 

--- a/src/css/blocks/process-block.css
+++ b/src/css/blocks/process-block.css
@@ -60,7 +60,7 @@
             & .step {
                 @apply relative flex flex-col items-start justify-end h-screen px-0 md:px-16 py-[6.125vh] md:py-[12.5vh];
 
-                & h2 {
+                & h3 {
                     @apply text-5xl font-bold text-csek-red mb-4;
                 }
 


### PR DESCRIPTION
## Description

Fixes #124

Removes `h1` tags from blocks that aren't supposed to be headings.