### PR TITLE
fix(expanding-media): add min-width to expanding media area

### DIFF
--- a/src/css/blocks/expanding-video-block.css
+++ b/src/css/blocks/expanding-video-block.css
@@ -15,10 +15,11 @@
         justify-content: center;
         align-items: flex-start;
         gap: 2rem;
+        @apply w-full;
     }
 
     & .expanding-video-container {
-        @apply w-11/12 md:w-[40vw] h-[75vh] overflow-hidden rounded-xl relative z-20 transition-all duration-1200 drop-shadow-md md:drop-shadow-none top-[2rem] bg-csek-dark;
+        @apply w-11/12 min-w-csek-1/2 md:w-[40vw] h-[75vh] overflow-hidden rounded-xl relative z-20 transition-all duration-1200 drop-shadow-md md:drop-shadow-none top-[2rem] bg-csek-dark;
 
         &.expanded {
             /* --local-ftb-shadow: var(--csek-dark); */


### PR DESCRIPTION
# Bug Fix for Guten Csek :microbe:

Fixes: #133

## Description

The `.expanding-video-container` div did not have a minium width and would shrink to zero on mobile.

## How was it fixed?

Added a `min-width` to the div of `csek-1/2` or $\frac{75}{2}\text{rem}$.

:fish_cake:
